### PR TITLE
refactor: simplify adapter functions with single config parameter

### DIFF
--- a/src/adapters/dynamodb/dynamodb.types.ts
+++ b/src/adapters/dynamodb/dynamodb.types.ts
@@ -1,4 +1,6 @@
-import { BaseRecord, DynamoDBKey, WithTimestamps, RecordWithTimestamps } from '../../shared/types';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { BaseRecord, DynamoDBKey, WithTimestamps, RecordWithTimestamps, Logger } from '../../shared/types';
+import { RecordValidator } from './dynamodb.validation';
 
 export interface DynamoDBAdapter<T extends BaseRecord = BaseRecord> {
   createOneRecord: (record: T & WithTimestamps) => Promise<T & RecordWithTimestamps>;
@@ -19,4 +21,11 @@ export interface DynamoDBClientDependencies {
   partitionKey: string;
   sortKey: string;
   gsiName: string;
+}
+
+export interface AdapterConfig<T extends BaseRecord = BaseRecord> {
+  client: DynamoDBDocumentClient;
+  deps: DynamoDBClientDependencies;
+  logger: Logger;
+  validator: RecordValidator<T>;
 }


### PR DESCRIPTION
## Summary
- Refactored adapter to use a single configuration parameter instead of four separate parameters
- Improved code maintainability and reduced parameter repetition
- All tests pass without any modifications

## Changes

### New Type Addition
- Added `AdapterConfig<T>` interface that consolidates:
  - `client: DynamoDBDocumentClient`
  - `deps: DynamoDBClientDependencies`
  - `logger: Logger`
  - `validator: RecordValidator<T>`

### Refactored Functions
Updated all 11 create functions to use the single config parameter:
- `createCreateOneRecord`
- `createFetchOneRecord`
- `createFetchManyRecords`
- `createDeleteOneRecord`
- `createReplaceOneRecord`
- `createPatchOneRecord`
- `createCreateManyRecords`
- `createDeleteManyRecords`
- `createPatchManyRecords`
- `createFetchAllRecords`
- `createCreateFetchAllRecords`

### Before/After Example
**Before:**
```typescript
const createXxx = <T>(client, deps, logger, validator) => ...
```

**After:**
```typescript
const createXxx = <T>(config: AdapterConfig<T>) => ...
```

## Benefits
- **Cleaner code**: Single parameter instead of four
- **Easier maintenance**: Changes to dependencies only require updating one type
- **Better scalability**: Easy to add new dependencies in the future
- **Reduced repetition**: No need to pass same four parameters to every function

## Test Plan
- [x] Run `npm run build` - TypeScript compilation successful
- [x] Run `npm run test:create` - ✅ Passed
- [x] Run `npm run test:fetch` - ✅ Passed
- [x] Run `npm run test:batch` - ✅ Passed
- [x] Run `npm run test:fetch-many` - ✅ Passed

All tests pass without any modifications, confirming this is a pure refactoring with no behavioral changes.

🤖 Generated with [Claude Code](https://claude.ai/code)